### PR TITLE
Add support for selecting a SKU using the query string idsku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for selecting a SKU using the query string `idsku`.
 
 ## [0.4.0] - 2019-10-30
 ### Added

--- a/react/ProductContextProvider.tsx
+++ b/react/ProductContextProvider.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, Dispatch } from 'react'
 import ProductContext from './ProductContext'
 import { ProductDispatchContext } from './ProductDispatchContext'
 import { useProductReducer, getSelectedItem } from './reducer'
+import { getSelectedSKUFromQueryString } from './modules/skuQueryString'
 
 function useProductInState(product: MaybeProduct, dispatch: Dispatch<Actions>) {
   useEffect(() => {
@@ -30,7 +31,8 @@ const ProductContextProvider: FC<ProductAndQuery> = ({ query, product, children 
 
   // These hooks are used to keep the state in sync with API data, specially when switching between products without exiting the product page
   useProductInState(product, dispatch)
-  useSelectedItemFromId(query.skuId, dispatch, product)
+  const selectedSkuQueryString = getSelectedSKUFromQueryString(query)
+  useSelectedItemFromId(selectedSkuQueryString, dispatch, product)
 
   return (
     <ProductContext.Provider value={state}>

--- a/react/modules/skuQueryString.ts
+++ b/react/modules/skuQueryString.ts
@@ -1,0 +1,7 @@
+interface QueryParams {
+  skuId?: string
+  idsku?: string
+}
+
+// `idsku` querystring is to keep compatibility with Google Shopping integration
+export const getSelectedSKUFromQueryString = (query: QueryParams) => query.skuId || query.idsku

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -1,5 +1,6 @@
 import { useReducer } from 'react'
 import { path, find, propEq, compose, flip, gt, pathOr } from 'ramda'
+import { getSelectedSKUFromQueryString } from '../modules/skuQueryString'
 
 const defaultState: ProductContextState = {
   product: undefined,
@@ -138,7 +139,7 @@ function initReducer({ query, product }: ProductAndQuery) {
   const items = (product && product.items) || []
   return {
     ...defaultState,
-    selectedItem: getSelectedItem(query.skuId, items),
+    selectedItem: getSelectedItem(getSelectedSKUFromQueryString(query), items),
     product,
   }
 }


### PR DESCRIPTION
Google Shopping integration links a SKU using the querystring `idsku` and not our `skuId`. They link to that querystring because that is how the standard CMS works.

The idea here is just to select the default sku. We are not updating this querystring when user selects a sku, we are still using `skuId`.