### PR TITLE
Add SELECT_IMAGE_VARIATION action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `SELECT_IMAGE_VARIATION` action.
 
 ## [0.7.0] - 2020-01-15
 ### Added

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -7,6 +7,7 @@ const defaultState: ProductContextState = {
   selectedItem: null,
   selectedQuantity: 1,
   skuSelector: {
+    selectedImageVariationSKU: null,
     isVisible: false,
     areAllVariationsSelected: true,
   },
@@ -30,6 +31,17 @@ function reducer(
       return {
         ...state,
         selectedQuantity: args.quantity,
+      }
+    }
+
+    case 'SELECT_IMAGE_VARIATION': {
+      const args = action.args || {}
+      return {
+        ...state,
+        skuSelector: {
+          ...state.skuSelector,
+          selectedImageVariationSKU: args.selectedImageVariationSKU,
+        },
       }
     }
 

--- a/react/typings/Context.ts
+++ b/react/typings/Context.ts
@@ -27,6 +27,7 @@ interface ProductContextState {
   product: MaybeProduct
   selectedQuantity: number
   skuSelector: {
+    selectedImageVariationSKU: string | null
     isVisible: boolean
     areAllVariationsSelected: boolean
   }
@@ -41,6 +42,10 @@ interface ProductContextState {
 type InputValues = Record<string, string>
 
 type Actions =
+  | Action<
+      'SELECT_IMAGE_VARIATION',
+      { args: { selectedImageVariationSKU: string | null } }
+    >
   | Action<'SET_QUANTITY', { args: { quantity: number } }>
   | Action<
       'SKU_SELECTOR_SET_VARIATIONS_SELECTED',


### PR DESCRIPTION
Add a new action that's dispatched when a image variation sku is selected/unselected.

Related to: https://github.com/vtex-apps/product-summary/pull/236 and https://github.com/vtex-apps/store-components/pull/701

#### How should this be manually tested?


1) https://kiwi--worldwidegolf.myvtex.com/
2) In `home`, check if the golf ball product is displaying a box
3) Click in a color variant
4) Image should change to that color
5) Click again, to remove the color
6) Should display the box again
