### PR TITLE
allow variation selection by querystring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for the `property__VariationName=Variation` query string.
+
 ## [0.7.1] - 2020-02-11
 ### Added
 - `SELECT_IMAGE_VARIATION` action.

--- a/react/ProductContextProvider.tsx
+++ b/react/ProductContextProvider.tsx
@@ -38,7 +38,10 @@ const ProductContextProvider: FC<ProductAndQuery> = ({
 
   // These hooks are used to keep the state in sync with API data, specially when switching between products without exiting the product page
   useProductInState(product, dispatch)
-  const selectedSkuQueryString = getSelectedSKUFromQueryString(query)
+  const selectedSkuQueryString = getSelectedSKUFromQueryString(
+    query,
+    (product && product.items) || []
+  )
   useSelectedItemFromId(dispatch, product, selectedSkuQueryString)
 
   return (

--- a/react/modules/skuQueryString.ts
+++ b/react/modules/skuQueryString.ts
@@ -3,5 +3,61 @@ interface QueryParams {
   idsku?: string
 }
 
+interface Variation {
+  name: string
+  value: string
+}
+
+const itemHasVariation = (item: Item, variation: Variation) => {
+  const { name, value } = variation
+
+  return Boolean(
+    item.variations.find(
+      variation =>
+        variation.name === name &&
+        variation.values.some(variationValue => variationValue === value)
+    )
+  )
+}
+
 // `idsku` querystring is to keep compatibility with Google Shopping integration
-export const getSelectedSKUFromQueryString = (query: QueryParams) => query.skuId || query.idsku
+export const getSelectedSKUFromQueryString = (
+  query: QueryParams,
+  items: Item[]
+) => {
+  const skuId = query.skuId || query.idsku
+
+  if (skuId) {
+    return skuId
+  }
+
+  const selectedVariations: Record<string, string> = {}
+
+  const propertyRegex = /^property__(.*)/
+
+  Object.entries(query).forEach(keyValue => {
+    const [key, value] = keyValue
+
+    const match = propertyRegex.exec(key)
+
+    if (!match) {
+      return
+    }
+
+    const [, variationName] = match
+    selectedVariations[variationName] = value
+  })
+
+  if (Object.entries(selectedVariations).length === 0) {
+    return
+  }
+
+  const selectedItem = items.find(item =>
+    Object.entries(selectedVariations).every(selectedVariation => {
+      const [name, value] = selectedVariation
+      return itemHasVariation(item, { name, value })
+    })
+  )
+
+  return selectedItem && selectedItem.itemId
+}

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "eslint-config-vtex": "^10.1.0",
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.16.4",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.62.2/public/_types/react"
   },
   "version": "0.7.1"

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -151,7 +151,10 @@ function initReducer({ query, product }: ProductAndQuery) {
   const items = (product && product.items) || []
   return {
     ...defaultState,
-    selectedItem: getSelectedItem(getSelectedSKUFromQueryString(query), items),
+    selectedItem: getSelectedItem(
+      getSelectedSKUFromQueryString(query, items),
+      items
+    ),
     product,
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5115,10 +5115,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What problem is this solving?

The intelligent search has a feature called split. Basically, instead of showing one product with three possible colors, we show three products, each one with one color.

Before split:
![image](https://user-images.githubusercontent.com/40380674/86956776-06821200-c130-11ea-8534-8824f1c2bd1e.png)
After split:
![image](https://user-images.githubusercontent.com/40380674/86956818-1863b500-c130-11ea-98b5-639ebb4aeaf3.png)

The problem is: when you click in one of those split products, the variation selected in the PLP will not be the one selected in the PDP.

To fix this, we decided to use a query string with this format: `?property__variationName=variationValue`. This way, we can select the variation by using a query string.

For example:

 - [Color pink](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Pink): `?property__Color=Pink`
- [Color black](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Black): `?property__Color=Black`
- [Color camel](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Camel): `?property__Color=Camel`

With this PR, the `product-context` will read those query strings and select the appropriate SKU.
#### How to test it?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

Click in any of the products. See that the variation in PDP is pre-selected.