### PR TITLE
split property__VariationName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- - Split the `property__VariationName` query string into `propertyName` and `propertyValue`.
+
 ## [0.8.0] - 2020-07-10
 
 ### Added

--- a/react/__tests__/ProductContextProvider.test.tsx
+++ b/react/__tests__/ProductContextProvider.test.tsx
@@ -8,13 +8,19 @@ import ProductDispatchContext from '../ProductDispatchContext'
 const { useProductDispatch } = ProductDispatchContext
 
 const ProductPageMock = () => {
-  const { selectedItem, product, selectedQuantity } = useContext(ProductContext) as any
+  const { selectedItem, product, selectedQuantity } = useContext(
+    ProductContext
+  ) as any
   return (
     <div>
       <div>Product Page</div>
       <div>Selected Item id: {selectedItem && selectedItem.itemId}</div>
       <div>Selected Item name: {selectedItem && selectedItem.name}</div>
-      {product ? <div>product slug: {product && product.linkText}</div> : <div>no product</div>}
+      {product ? (
+        <div>product slug: {product && product.linkText}</div>
+      ) : (
+        <div>no product</div>
+      )}
       <div>Selected Quantity: {selectedQuantity}</div>
     </div>
   )
@@ -43,13 +49,18 @@ describe('ProductContextProvider component', () => {
     return {
       ...component,
       testNoProduct: () => getByText('no product'),
-      getSelectedItemId: (item: { itemId: string }) => getByText(`Selected Item id: ${item.itemId}`),
+      getSelectedItemId: (item: { itemId: string }) =>
+        getByText(`Selected Item id: ${item.itemId}`),
       getSelectedItemName: (item: { name: string }) =>
         getByText(`Selected Item name: ${item.name}`),
-      getProductSlug: (product: { linkText: string }) => getByText(`product slug: ${product.linkText}`),
-      rerender: (newProps: any) => rerender(<ProductContextProvider {...newProps}>
-        <ProductPageMock />
-      </ProductContextProvider>)
+      getProductSlug: (product: { linkText: string }) =>
+        getByText(`product slug: ${product.linkText}`),
+      rerender: (newProps: any) =>
+        rerender(
+          <ProductContextProvider {...newProps}>
+            <ProductPageMock />
+          </ProductContextProvider>
+        ),
     }
   }
 
@@ -60,7 +71,9 @@ describe('ProductContextProvider component', () => {
   })
 
   it('should render with no product and then switch', () => {
-    const { getProductSlug, rerender, testNoProduct } = renderComponent({ product: undefined })
+    const { getProductSlug, rerender, testNoProduct } = renderComponent({
+      product: undefined,
+    })
 
     testNoProduct()
 
@@ -141,12 +154,102 @@ describe('ProductContextProvider component', () => {
     getSelectedItemName(itemtwo)
   })
 
+  it('should select the first available product with the variation set in propertyName and propertyValue', async () => {
+    const itemOne = getItem('1', 90, 1, {
+      variations: [
+        {
+          name: 'Color',
+          values: ['Blue'],
+        },
+      ],
+    })
+
+    const itemTwo = getItem('2', 90, 0, {
+      variations: [
+        {
+          name: 'Color',
+          values: ['Red'],
+        },
+      ],
+    })
+
+    const itemThree = getItem('3', 90, 1, {
+      variations: [
+        {
+          name: 'Color',
+          values: ['Red'],
+        },
+      ],
+    })
+
+    const newProduct = getProduct({
+      items: [itemOne, itemTwo, itemThree],
+    })
+
+    const props = {
+      product: newProduct,
+      params: { slug: newProduct.linkText },
+      productQuery: {
+        product: newProduct,
+        loading: false,
+      },
+      query: { propertyName: 'Color', propertyValue: 'Red' },
+    }
+    const { getSelectedItemId, getSelectedItemName } = renderComponent(props)
+
+    getSelectedItemId(itemThree)
+    getSelectedItemName(itemThree)
+  })
+
+  it('should select the first available item when there is no item with the variation set in propertyName and propertyValue', async () => {
+    const itemOne = getItem('1', 90, 0, {
+      variations: [
+        {
+          name: 'Color',
+          values: ['Blue'],
+        },
+      ],
+    })
+
+    const itemTwo = getItem('2', 90, 1, {
+      variations: [
+        {
+          name: 'Color',
+          values: ['Red'],
+        },
+      ],
+    })
+
+    const newProduct = getProduct({
+      items: [itemOne, itemTwo],
+    })
+
+    const props = {
+      product: newProduct,
+      params: { slug: newProduct.linkText },
+      productQuery: {
+        product: newProduct,
+        loading: false,
+      },
+      query: { propertyName: 'Color', propertyValue: 'Black' },
+    }
+    const { getSelectedItemId, getSelectedItemName } = renderComponent(props)
+
+    getSelectedItemId(itemTwo)
+    getSelectedItemName(itemTwo)
+  })
+
   it('should dispatch action with bad args and not break anything', () => {
     const BadComponent = () => {
       const dispatch = useProductDispatch()
       dispatch && dispatch({ type: 'SET_QUANTITY', quantity: 1 } as any)
-      dispatch && dispatch({ type: 'SKU_SELECTOR_SET_VARIATIONS_SELECTED', quantity: 1 } as any)
-      dispatch && dispatch({ type: 'SKU_SELECTOR_SET_IS_VISIBLE', quantity: 1 } as any)
+      dispatch &&
+        dispatch({
+          type: 'SKU_SELECTOR_SET_VARIATIONS_SELECTED',
+          quantity: 1,
+        } as any)
+      dispatch &&
+        dispatch({ type: 'SKU_SELECTOR_SET_IS_VISIBLE', quantity: 1 } as any)
       dispatch && dispatch({ type: 'SET_SELECTED_ITEM', quantity: 1 } as any)
       dispatch && dispatch({ type: 'SET_ASSEMBLY_OPTIONS', quantity: 1 } as any)
       dispatch && dispatch({ type: 'SET_PRODUCT', quantity: 1 } as any)

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -137,7 +137,7 @@ const isSkuAvailable = compose<Seller, number, boolean>(
 )
 
 const findItemById = (id: string) => find<Item>(propEq<string>('itemId', id))
-function findAvailableProduct(item: Item) {
+export function findAvailableProduct(item: Item) {
   return item.sellers.find(isSkuAvailable)
 }
 


### PR DESCRIPTION
#### What problem is this solving?

In the https://github.com/vtex-apps/product-context/pull/26 we introduced a new query string: the `property__VariationName: VariationValue`. Unfortunately, this query string [can't be added to the cache whitelist](https://github.com/vtex/reliability/issues/2053#issuecomment-662417601) since it is a regex.

This PR splits the `property__` query string into two new ones: `propertyName` and `propertyValye`

##### Example:
Before PR: `?porperty__Color=Blue&property__Size=G`
After PR: `?porpertyName=Color,Size&propertyValue=Blue,G` 

Feel free to suggest me any other query string format ✌️ 

#### How to test it?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

Click in any of the products. See that the variation in PDP is pre-selected.

#### Related to / Depends on
- https://github.com/vtex-apps/product-summary-context/pull/13