### PR TITLE
Move productClusters to Product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+-  Move `productClusters` typings definitions to `Product` type.
 
 ## [0.9.0] - 2020-09-15
 ### Added

--- a/react/ProductTypes.ts
+++ b/react/ProductTypes.ts
@@ -2,61 +2,41 @@ type Maybe<T> = T | null | undefined
 
 export type MaybeProduct = Maybe<Product>
 
-export interface Product {
-  cacheId: string
-  productName: string
-  productId: string
-  description: string
-  titleTag: string
-  metaTagDescription: string
-  linkText: string
-  link: string
-  productReference: string
-  categoryId: string
-  categoriesIds: string[]
-  categories: string[]
-  categoryTree: Array<{
-    id: string
-    name: string
-    href: string
-  }>
+export type Product = {
   brand: string
   brandId: string
-  properties: Array<{
-    name: string
-    values: string
-  }>
-  specificationGroups: Array<{
-    name: string
-    specifications: Array<{
-      name: string
-      values: string[]
-    }>
-  }>
+  cacheId: string
+  categories: string[]
+  categoriesIds: string[]
+  categoryId: string
+  categoryTree: Array<{ id: string; name: string; href: string }>
+  clusterHighlights: Array<{ id: string; name: string }>
+  description: string
+  itemMetadata: { items: ItemMetadata[]; priceTable: any[] }
   items: Item[]
-  skuSpecifications: SkuSpecification[]
-  itemMetadata: {
-    items: ItemMetadata[]
-    priceTable: any[]
-  }
+  link: string
+  linkText: string
+  metaTagDescription: string
   priceRange: {
     sellingPrice: { highPrice: number; lowPrice: number }
     listPrice: { highPrice: number; lowPrice: number }
   }
+  productClusters: Array<{ id: string; name: string }>
+  productId: string
+  productName: string
+  productReference: string
+  properties: Array<{ name: string; values: string }>
+  skuSpecifications: SkuSpecification[]
+  specificationGroups: Array<{
+    name: string
+    specifications: Array<{ name: string; values: string[] }>
+  }>
+  titleTag: string
 }
 
-export interface Item {
-  itemId: string
-  name: string
-  nameComplete: string
+export type Item = {
   complementName: string
   ean: string
-  referenceId: Array<{
-    Key: string
-    Value: string
-  }>
-  measurementUnit: string
-  unitMultiplier: number
   images: Array<{
     imageId: string
     imageLabel: string
@@ -64,38 +44,31 @@ export interface Item {
     imageUrl: string
     imageText: string
   }>
-  videos: Array<{
-    videoUrl: string
-  }>
+  itemId: string
+  measurementUnit: string
+  name: string
+  nameComplete: string
+  referenceId: Array<{ Key: string; Value: string }>
   sellers: Seller[]
-  variations: Array<{
-    name: string
-    values: string[]
-  }>
-  productClusters: Array<{
-    id: string
-    name: string
-  }>
-  clusterHighlights: Array<{
-    id: string
-    name: string
-  }>
+  unitMultiplier: number
+  variations: Array<{ name: string; values: string[] }>
+  videos: Array<{ videoUrl: string }>
 }
 
-export interface SkuSpecification {
+export type SkuSpecification = {
   field: SkuSpecificationField
   values: SkuSpecificationValues[]
 }
 
-export interface SkuSpecificationField {
+export type SkuSpecificationField = {
   name: string
 }
 
-export interface SkuSpecificationValues {
+export type SkuSpecificationValues = {
   name: string
 }
 
-export interface Seller {
+export type Seller = {
   sellerId: string
   sellerName: string
   addToCartLink: string
@@ -103,14 +76,10 @@ export interface Seller {
   commertialOffer: CommercialOffer
 }
 
-export interface CommercialOffer {
+export type CommercialOffer = {
   Installments: Installment[]
-  discountHighlights: Array<{
-    name: string
-  }>
-  teasers: Array<{
-    name: string
-  }>
+  discountHighlights: Array<{ name: string }>
+  teasers: Array<{ name: string }>
   Price: number
   ListPrice: number
   spotPrice: number
@@ -124,7 +93,7 @@ export interface CommercialOffer {
   CacheVersionUsedToCallCheckout: string
 }
 
-export interface Installment {
+export type Installment = {
   Value: number
   InterestRate: number
   TotalValuePlusInterestRate: number
@@ -134,7 +103,7 @@ export interface Installment {
   Name: string
 }
 
-export interface ItemMetadata {
+export type ItemMetadata = {
   items: Array<{
     id: string
     name: string
@@ -150,11 +119,7 @@ export interface ItemMetadata {
   }>
   priceTable: Array<{
     type: string
-    values: Array<{
-      id: string
-      assemblyId: string
-      price: number | null
-    }>
+    values: Array<{ id: string; assemblyId: string; price: number | null }>
   }>
 }
 
@@ -166,7 +131,7 @@ const enum InputValueType {
   'OPTIONS' = 'OPTIONS',
 }
 
-export interface TextInputValue {
+export type TextInputValue = {
   type: InputValueType.TEXT
   defaultValue: ''
   label: string
@@ -174,7 +139,7 @@ export interface TextInputValue {
   domain: null
 }
 
-export interface BooleanInputValue {
+export type BooleanInputValue = {
   type: InputValueType.BOOLEAN
   defaultValue: boolean
   label: string
@@ -182,7 +147,7 @@ export interface BooleanInputValue {
   domain: null
 }
 
-export interface OptionsInputValue {
+export type OptionsInputValue = {
   type: InputValueType.OPTIONS
   defaultValue: string
   label: string
@@ -190,7 +155,7 @@ export interface OptionsInputValue {
   domain: string[]
 }
 
-export interface Composition {
+export type Composition = {
   minQuantity: number
   maxQuantity: number
   items: Array<{


### PR DESCRIPTION
#### What problem is this solving?

Fix the location of the type for `product.productClusters`. 

For reference, see the graphql `Product` type: https://github.com/vtex-apps/store-graphql/blob/master/graphql/types/Product.graphql#L17

#### How to test it?

n/a

#### Screenshots or example usage:

n/a

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/vhsNmFjuN4WDS/giphy.gif)
