### PR TITLE
Fix specificationGroups typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Typings for `specificationGroups`.
 
 ## [0.9.2] - 2020-10-09
 ### Fixed

--- a/react/ProductTypes.ts
+++ b/react/ProductTypes.ts
@@ -4,6 +4,16 @@ export type MaybeProduct = Maybe<Product>
 
 export type ProductSpecification = { name: string; values: string[] }
 
+export type SpecificationGroupItem = {
+  originalName: string
+} & ProductSpecification
+
+export type SpecificationGroup = {
+  name: string
+  originalName: string
+  specifications: SpecificationGroupItem
+}
+
 export type Product = {
   brand: string
   brandId: string
@@ -29,10 +39,7 @@ export type Product = {
   productReference: string
   properties: ProductSpecification[]
   skuSpecifications: SkuSpecification[]
-  specificationGroups: Array<{
-    name: string
-    specifications: ProductSpecification[]
-  }>
+  specificationGroups: SpecificationGroup[]
   titleTag: string
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Fix missing typings for `specificationGroups`.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/iGvWZBfhOmBKEtWJmF/giphy-downsized.gif)
