### PR TITLE
Fix teasers types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `teasers` types.
 
 ## [0.9.2] - 2020-10-09
 ### Fixed

--- a/react/ProductTypes.ts
+++ b/react/ProductTypes.ts
@@ -78,10 +78,25 @@ export type Seller = {
   commertialOffer: CommercialOffer
 }
 
+type TeaserCondition = {
+  minimumQuantity: number
+  parameters: Array<{ name: string, value: string }>
+}
+
+type TeaserEffects = {
+  parameters: Array<{ name: string, value: string }>
+}
+
+export type Teaser = {
+  name: string
+  conditions: TeaserCondition
+  effects: TeaserEffects
+}
+
 export type CommercialOffer = {
   Installments: Installment[]
   discountHighlights: Array<{ name: string }>
-  teasers: Array<{ name: string }>
+  teasers: Teaser[]
   Price: number
   ListPrice: number
   spotPrice: number

--- a/react/package.json
+++ b/react/package.json
@@ -9,7 +9,7 @@
     "@types/react": "^16.8.13",
     "@vtex/test-tools": "^3.1.0",
     "react-intl": "^5.4.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.62.2/public/_types/react"
   },
   "version": "0.9.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5170,12 +5170,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?

Add missing types of teasers

https://github.com/vtex-apps/search-graphql/blob/master/graphql/types/Product.graphql#L312-L325


#### How to test it?

n/a

#### Screenshots or example usage:

n/a

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
