### PR TITLE
Fix Product Dispatch context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product Dispatch context.
 
 ## [0.9.5] - 2020-12-10
 ### Fixed

--- a/react/ProductDispatchContext.ts
+++ b/react/ProductDispatchContext.ts
@@ -1,10 +1,14 @@
-import { createContext, Dispatch } from 'react'
+import type { Dispatch } from 'react'
+import { createContext, useContext } from 'react'
 
-import { Actions } from './ProductContextProvider'
-import useProductDispatch from './useProductDispatch'
+import type { Actions } from './ProductContextProvider'
 
 export const ProductDispatchContext = createContext<Dispatch<Actions> | null>(
   null
 )
+
+function useProductDispatch() {
+  return useContext(ProductDispatchContext)
+}
 
 export default { ProductDispatchContext, useProductDispatch }


### PR DESCRIPTION
#### What problem is this solving?

The hook useProductDispatch was throwing errors when being used by add-to-cart-button (see https://github.com/vtex-apps/add-to-cart-button/pull/57) and product-summary (see https://github.com/vtex-apps/product-summary/pull/289)

#### How to test it?

1. Open a development workspace in carrefourbrfood
2. Link vtex.add-to-cart-button@0.20.2 (that is the version that was deprecated)
3. Link vtex.product-summary@2.66.0 (that is the version before it was fixed)
4. Run `vtex browse busca/banana`
5. Check for errors happening
6. Now link this PR

With previous versions + PR linked:
https://brenovtex--carrefourbrfood.myvtex.com/busca/banana
<img src="https://user-images.githubusercontent.com/284515/102126546-f7636680-3e29-11eb-91da-fd40e3aa96a0.png" width=460 />


With current state + PR linked:
https://brenovtex2--carrefourbrfood.myvtex.com/busca/banana
<img src="https://user-images.githubusercontent.com/284515/102126503-eb77a480-3e29-11eb-8310-57004558a99a.png" width=460 />

#### Screenshots or example usage:

n/a

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/ddtag25At6ZsmKR91a/giphy.gif)
