### PR TITLE
Fix context update when prefetch is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Product State context not being updated when prefetch is enabled.
+
 ## [0.9.6] - 2020-12-15
 ### Fixed
 - Product Dispatch context.

--- a/react/ProductContextProvider.tsx
+++ b/react/ProductContextProvider.tsx
@@ -77,17 +77,6 @@ export type Actions =
     >
   | Action<'SET_PRODUCT', { args: { product: MaybeProduct } }>
 
-function useProductInState(product: MaybeProduct, dispatch: Dispatch<Actions>) {
-  useEffect(() => {
-    if (product) {
-      dispatch({
-        type: 'SET_PRODUCT',
-        args: { product },
-      })
-    }
-  }, [product, dispatch])
-}
-
 function useSelectedItemFromId(
   dispatch: Dispatch<Actions>,
   product: MaybeProduct,
@@ -110,8 +99,14 @@ const ProductContextProvider: FC<ProductAndQuery> = ({
 }) => {
   const [state, dispatch] = useProductReducer({ query, product })
 
-  // These hooks are used to keep the state in sync with API data, specially when switching between products without exiting the product page
-  useProductInState(product, dispatch)
+  // It is used to keep the state in sync with API data, specially when switching between products without exiting the product page
+  if (product && (product.productId !== state?.product?.productId)) {
+    dispatch({
+      type: 'SET_PRODUCT',
+      args: { product },
+    })
+  }
+
   const selectedSkuQueryString = getSelectedSKUFromQueryString(
     query,
     product?.items


### PR DESCRIPTION
#### What problem is this solving?

When prefetch is enabled, moving from a product page to another, the first render comes with an old data from the context. Replacing the hook that verifies subsequent updates based on a dependency array to a simple `if` that verifies when the state should be updated, solves the problem. [thread here](https://vtex.slack.com/archives/C01BCQV3U68/p1608215433029300).

#### How to test it?

1) Go to [https://vitorflg--polishop.myvtex.com/aparador-multigroom-evolution-philips/p](https://vitorflg--polishop.myvtex.com/aparador-multigroom-evolution-philips/p)
2) Click on the search icon
3) Search for `airfryer`
4) Hover the airfryer product link for at least 5 seconds and click on it.
<img width="1385" alt="Screen Shot 2020-12-21 at 11 10 33 AM" src="https://user-images.githubusercontent.com/13058968/102785742-3428e380-437d-11eb-8d0e-12ffa0ec6f96.png">
5. The video and the images should be ok, with the right data.

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

I think about fixing this problem in the Prefetch component of the render-runtime or maybe changing the behaviour of the useMemo on the Product Images component but the root seems to be here.

#### Related to / Depends on

X

