### PR TITLE
Fix Typing for Product Item Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed typing for product item metadata
 
 ## [0.9.7] - 2020-12-21
 ### Fixed

--- a/react/ProductTypes.ts
+++ b/react/ProductTypes.ts
@@ -33,7 +33,7 @@ export type Product = {
   categoryTree: Array<{ id: string; name: string; href: string }>
   clusterHighlights: Array<{ id: string; name: string }>
   description: string
-  itemMetadata: { items: ItemMetadata[]; priceTable: any[] }
+  itemMetadata: ItemMetadata
   items: Item[]
   link: string
   linkText: string


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes typings for `itemMetadata` in the product in accordance with the actual data structure we get from the search GraphQL.
