### PR TITLE
Fix Typing for Assembly Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed typing for assembly options
 
 ## [0.9.8] - 2021-03-30
 ### Fixed

--- a/react/ProductTypes.ts
+++ b/react/ProductTypes.ts
@@ -148,13 +148,13 @@ export type ItemMetadata = {
     name: string
     imageUrl: string
     seller: string
-    assemblyOptions: {
+    assemblyOptions: Array<{
       id: string
       name: string
       required: boolean
       inputValues: InputValue[]
       composition: Composition | null
-    }
+    }>
   }>
   priceTable: Array<{
     type: string


### PR DESCRIPTION
#### What problem is this solving?

Fix assembly option typing for item metadata in accordance with the result from search GraphQL.
