### PR TITLE
Add loadingItem property to ProductContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `loadingItem` to product context
+- Action `SET_LOADING_ITEM` to product context dispatch.
 
 ## [0.9.9] - 2021-03-30
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ The function is capable of performing the following `actions`:
 - `SET_SELECTED_ITEM`: Sets the value for the `selectedItem` property.
 - `SET_ASSEMBLY_OPTIONS`: Sets the value for the `assemblyOptions` property.
 - `SET_PRODUCT`: Sets the value for the `product` property.
-- `SET_LOADING_ITEM`: Sets the value if a selected item is loadind or not.
+- `SET_LOADING_ITEM`: Sets the value if a selected item is loading or not.
 
 :information_source: *To have the full type definition in your development environment, be sure to run `vtex setup` in your project to install all TypeScript types exported by this app.*
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ The function is capable of performing the following `actions`:
 - `SET_SELECTED_ITEM`: Sets the value for the `selectedItem` property.
 - `SET_ASSEMBLY_OPTIONS`: Sets the value for the `assemblyOptions` property.
 - `SET_PRODUCT`: Sets the value for the `product` property.
+- `SET_LOADING_ITEM`: Sets the value if a selected item is loadind or not.
 
 :information_source: *To have the full type definition in your development environment, be sure to run `vtex setup` in your project to install all TypeScript types exported by this app.*
 

--- a/react/ProductContextProvider.tsx
+++ b/react/ProductContextProvider.tsx
@@ -35,6 +35,7 @@ export interface SkuSelectorContextState {
 }
 
 export interface ProductContextState {
+  loadingItem: boolean
   selectedItem?: Item | null
   product: MaybeProduct
   selectedQuantity: number
@@ -76,6 +77,7 @@ export type Actions =
       }
     >
   | Action<'SET_PRODUCT', { args: { product: MaybeProduct } }>
+  | Action<'SET_LOADING_ITEM', { args: { loadingItem: boolean } }>
 
 function useProductInState(product: MaybeProduct, dispatch: Dispatch<Actions>) {
   useEffect(() => {

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -104,7 +104,7 @@ function reducer(
     case 'SET_LOADING_ITEM': {
       return {
         ...state,
-        loadingItem: !!action.args.loadingItem
+        loadingItem: Boolean(action.args.loadingItem),
       }
     }
 

--- a/react/reducer/index.ts
+++ b/react/reducer/index.ts
@@ -10,6 +10,7 @@ import type {
 } from '../ProductContextProvider'
 
 const defaultState: ProductContextState = {
+  loadingItem: false,
   product: undefined,
   selectedItem: null,
   selectedQuantity: 1,
@@ -95,7 +96,15 @@ function reducer(
 
       return {
         ...state,
+        loadingItem: false,
         selectedItem: args.item,
+      }
+    }
+
+    case 'SET_LOADING_ITEM': {
+      return {
+        ...state,
+        loadingItem: !!action.args.loadingItem
       }
     }
 


### PR DESCRIPTION
#### What problem is this solving?
Prevent the user clicks on this button while the new selectedItem is being processed.

Add the loadingItem property, to ProductContext, to allow SKUSelector to change this property to disable the `add to cart button`. The add to cart button disabled while `loadingItem` is true.

#### How to test it?
[Workspace](https://brasileiro--melisseiras.myvtex.com/melissa-sun-rodeo-vermelho-33530/p?skuId=135439)

1. Chose another SKU, via SKU selector
2. Click on add to cart button
3. Check if the correct SKU is added on minicart.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/duL28c2tptZ0zAopCf/giphy.gif)
