### PR TITLE
Add support for selecting a seller using the query string selectedSeller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Support for selecting a unique seller by query param `selectedSeller`
 
 ## [0.10.0] - 2021-08-03
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

- Add support for selecting a unique seller by query param `selectedSeller`

#### How to test it?

[Workspace](https://ms0215797structureddata--shopfacilio.myvtex.com/ventilador-philco-de-mesa-pvt400-40-cm-preto-1171581435/p?selectedSeller=Extra)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3ohhwF34cGDoFFhRfy/giphy.gif)
